### PR TITLE
fix: preserve relaxed structure visualization during MD

### DIFF
--- a/utils/app_relax.py
+++ b/utils/app_relax.py
@@ -1,8 +1,9 @@
 """Provides functions for setting up and performing structure relaxation using Mattersim."""
 
 import streamlit as st
-from mattersim.applications.relax import Relaxer
 from ase.units import GPa
+from mattersim.applications.relax import Relaxer
+
 
 # %% Structure relaxation sidebar
 def setup_relaxation_sidebar():
@@ -37,13 +38,13 @@ def setup_relaxation_sidebar():
     if "fmax" not in st.session_state:
         st.session_state.fmax = 0.01
     if "pressure" not in st.session_state:
-        st.session_state.pressure= 0.0
+        st.session_state.pressure = 0.0
 
     col1, col2 = st.sidebar.columns(2)
     with col1:
-        pressure = st.number_input("Pressure",
-                                value = st.session_state.pressure,
-                                min_value=0.0)
+        pressure = st.number_input(
+            "Pressure", value=st.session_state.pressure, min_value=0.0
+        )
         """"
         The scalar_pressure used in ExpCellFilter assumes eV/A^3 unit
               and 1 eV/A^3 is already 160 GPa. Please make sure you have
@@ -51,41 +52,37 @@ def setup_relaxation_sidebar():
               160.21766208 (or multiply by GPa from ase.units)."
         """
     with col2:
-        unit = st.pills("Unit",
-                        ["GPa", "eV/A^3"],
-                        default="GPa",
-                        key="unit")
+        unit = st.pills("Unit", ["GPa", "eV/A^3"], default="GPa", key="unit")
 
     if unit == "GPa":
-        pressure *=GPa
+        pressure *= GPa
 
     optimizer = st.sidebar.pills(
-        "Optimizer", 
+        "Optimizer",
         ["BFGS", "FIRE"],
         selection_mode="single",
         default=st.session_state.optimizer,
-        key="optimizer"
+        key="optimizer",
     )
     st.sidebar.caption("""
                        **BFGS**: A quasi-Newton method. Generally a good choice for many systems. Balances speed and accuracy. Approximates the Hessian matrix.\n
                        **FIRE**: Good for systems that are "difficult" to relax. Uses a combination of Newtonian dynamics and friction. Can be slower per step than BFGS.
-                       """
-    )
+                       """)
 
     steps = st.sidebar.slider(
-        "Maximum Relaxation Steps", 
+        "Maximum Relaxation Steps",
         value=st.session_state.steps,
         min_value=0,
         max_value=5000,
         step=500,
-        key="steps"
+        key="steps",
     )
 
-    filtering = st.sidebar.pills("Filter",
-                                  ["ExpCellFilter", "FrechetCellFilter", "None"],
-                                  default=st.session_state.filtering,
-                                  key="filtering",
-
+    filtering = st.sidebar.pills(
+        "Filter",
+        ["ExpCellFilter", "FrechetCellFilter", "None"],
+        default=st.session_state.filtering,
+        key="filtering",
     )
     if filtering == "None":
         filtering = None
@@ -93,27 +90,37 @@ def setup_relaxation_sidebar():
     st.sidebar.caption("""
                        Filters are designed to enable simultaneous relaxation of atomic positions and the unit cell shape.
                        *ASE recommends using FrechetCellFilter over ExpCellFilter due to its better convergence properties, especially concerning the cell variables.*
-                       """
-                       )
+                       """)
 
-    constrain_symmetry = st.sidebar.checkbox("Constrain Symmetry",
-                                             value=st.session_state.constrain_symmetry,
-                                             key="constrain_symmetry")
+    constrain_symmetry = st.sidebar.checkbox(
+        "Constrain Symmetry",
+        value=st.session_state.constrain_symmetry,
+        key="constrain_symmetry",
+    )
 
-    fmax = st.sidebar.number_input("fmax",
-                                   value = st.session_state.fmax,
-                                   key = "fmax",
-                                   min_value=0.01,
-                                   step = 0.01,
-                                   help = "The maximum force allowed.")
+    fmax = st.sidebar.number_input(
+        "fmax",
+        value=st.session_state.fmax,
+        key="fmax",
+        min_value=0.01,
+        step=0.01,
+        help="The maximum force allowed.",
+    )
 
     return optimizer, steps, filtering, constrain_symmetry, fmax, pressure, unit
 
+
 # %%
-def perform_relaxation(basis_positions, structure,
-                       optimizer, steps,
-                       filtering, constrain_symmetry,
-                       fmax, pressure):
+def perform_relaxation(
+    basis_positions,
+    structure,
+    optimizer,
+    steps,
+    filtering,
+    constrain_symmetry,
+    fmax,
+    pressure,
+):
     """Performs structure relaxation.
 
     Args:
@@ -134,7 +141,7 @@ def perform_relaxation(basis_positions, structure,
     """
 
     if basis_positions is None:
-        st.warning("Basis positions is None." , icon="⚠️")
+        st.warning("Basis positions is None.", icon="⚠️")
         st.stop()
 
     with st.spinner("Starting relaxation..."):
@@ -143,7 +150,7 @@ def perform_relaxation(basis_positions, structure,
             relaxer = Relaxer(
                 optimizer=optimizer,
                 filter=filtering,
-                constrain_symmetry=constrain_symmetry
+                constrain_symmetry=constrain_symmetry,
             )
         except Exception as e:
             st.error(f"Failed to initialize relaxer: {str(e)}", icon="🚨")
@@ -151,27 +158,52 @@ def perform_relaxation(basis_positions, structure,
 
         # Perform relaxation
         try:
-            relaxed_structure = relaxer.relax(structure,
-                                              steps=steps,
-                                              fmax=fmax,
-                                              params_filter={"scalar_pressure": pressure})
-            # Store the relaxed structure in session_state to persist it across re-runs
-            if relaxed_structure:
-                st.session_state.relaxed_structure = relaxed_structure
-                st.success(f"""
-                            **Relaxation completed with:**  \n
-                            **Optimizer:** {optimizer}\n
-                            **Filter:** {filtering}\n
-                            **Maximum force:** {fmax}\n
-                            **Symmetry constrained:** {constrain_symmetry}\n
-                            **Relaxation steps:** {steps}\n
-                            **Pressure in eV/Å³:** {pressure:.5f}\n
-                            **Pressure in GPa:** {pressure/GPa:.5f}"""
-                                                , icon="✅")
+            result = relaxer.relax(
+                structure,
+                steps=steps,
+                fmax=fmax,
+                params_filter={"scalar_pressure": pressure},
+            )
 
-                return relaxed_structure
-            st.error("Relaxer did not return relaxed structure.", icon="🚨")
-            st.stop()
+            # Check if result is a tuple (success_flag, relaxed_structure)
+            if isinstance(result, tuple):
+                success = result[0]
+                if not success:
+                    st.error(
+                        "Relaxation failed: Optimizer returned failure flag", icon="🚨"
+                    )
+                    st.stop()
+                relaxed_structure = result[1]  # Get the Atoms object from the tuple
+            else:
+                relaxed_structure = result
+
+            # Check if we got a valid structure back
+            if relaxed_structure is None:
+                st.error("Relaxation failed: No structure returned", icon="🚨")
+                st.stop()
+
+            # Copy the calculator from the original structure
+            relaxed_structure.calc = structure.calc
+
+            # Store the relaxed structure in session_state to persist it across re-runs
+            st.session_state.relaxed_structure = relaxed_structure.copy()
+            # Reattach calculator to the stored structure
+            st.session_state.relaxed_structure.calc = structure.calc
+
+            st.success(
+                f"""
+                        **Relaxation completed with:**  \n
+                        **Optimizer:** {optimizer}\n
+                        **Filter:** {filtering}\n
+                        **Maximum force:** {fmax}\n
+                        **Symmetry constrained:** {constrain_symmetry}\n
+                        **Relaxation steps:** {steps}\n
+                        **Pressure in eV/Å³:** {pressure:.5f}\n
+                        **Pressure in GPa:** {pressure/GPa:.5f}""",
+                icon="✅",
+            )
+
+            return relaxed_structure
 
         except Exception as e:
             st.error(f"Relaxation failed: {str(e)}", icon="🚨")


### PR DESCRIPTION
- Use st.session_state.relaxed_structure instead of structure variable when displaying relaxation results
- Ensures relaxed structure view remains unchanged when running MD simulation
- Maintains independent visualizations for both relaxed and MD states

The main issue was that the relaxation results were using the mutable structure variable which gets modified during MD simulation. Now we use the preserved relaxed structure from session state to keep the views separate.

fixed #1